### PR TITLE
Add option to specify Image pull policy

### DIFF
--- a/charts/tiphys/templates/app.yaml
+++ b/charts/tiphys/templates/app.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
         - name: {{ include "opszero.fullname" $ }}
           image: {{ default $.Values.defaultImage $app.image | quote }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ default "Always" $app.imagePullPolicy | quote }}
           command: ["bash", "-c", {{ $job.command | join " " | quote}}]
           envFrom:
             - secretRef:
@@ -110,7 +110,7 @@ spec:
       containers:
         - name: {{ $.Chart.Name }}
           image: {{ default $.Values.defaultImage $app.image | quote }}
-          imagePullPolicy: Always
+          imagePullPolicy: {{ default "Always" $job.imagePullPolicy | quote }}
           {{- if $app.service.command }}
           command: ["bash", "-c", {{ $app.service.command | join " " | quote}}]
           {{- end }}


### PR DESCRIPTION
Running local k8s(minikube) we have to specify that imagepull policy to never so that we don't have to use push docker images to repo and easy to develop/deploy locally

https://minikube.sigs.k8s.io/docs/handbook/pushing/#1-pushing-directly-to-the-in-cluster-docker-daemon-docker-env